### PR TITLE
fix for regexes containing negations

### DIFF
--- a/solvertools/regextools.py
+++ b/solvertools/regextools.py
@@ -193,7 +193,7 @@ def _regex_index(struct, index):
         return _regex_index_pattern(struct, index)
     else:
         opcode, data = struct
-        if opcode in (LITERAL, IN, CATEGORY, ANY):
+        if opcode in (LITERAL, IN, CATEGORY, ANY, NOT_LITERAL):
             if index == 0:
                 return [[struct]]
             else:
@@ -204,8 +204,6 @@ def _regex_index(struct, index):
             return _regex_index_branch(data[-1], index)
         elif opcode == MAX_REPEAT:
             return _regex_index_repeat(data, index)
-        elif opcode == NOT_LITERAL:
-            raise NotImplementedError
         elif opcode == NEGATE:
             print(struct)
             raise NotImplementedError

--- a/solvertools/wordlist.py
+++ b/solvertools/wordlist.py
@@ -209,7 +209,7 @@ class Wordlist:
                 self._grep_maps[cur_length] = mm
             else:
                 mm = self._grep_maps[cur_length]
-            pbytes = pattern.encode('ascii')
+            pbytes = pattern.encode('ascii').replace(b'[^',b'[^,')
             pattern1 = b'^' + pbytes + b','
             pattern2 = b'\n' + pbytes + b','
             match = re.match(pattern1, mm)


### PR DESCRIPTION
This fixes #4 as well as the following separate issue:  a search for something like `[^AB]*` would fail because `[^AB]*` would match an entire line from the greppable wordlist files, including the comma and frequency.